### PR TITLE
Add resources.Dns.OwnerShipTokenRecordName

### DIFF
--- a/resources/resources.go
+++ b/resources/resources.go
@@ -474,16 +474,17 @@ type Csvimport struct {
 
 // Dns: Sender Domain properties.
 type Dns struct {
-	DKIMRecordName    string           `mailjet:"read_only"`
-	DKIMRecordValue   string           `mailjet:"read_only"`
-	DKIMStatus        string           `mailjet:"read_only"`
-	Domain            string           `mailjet:"read_only"`
-	ID                int64            `mailjet:"read_only"`
-	IsCheckInProgress bool             `mailjet:"read_only"`
-	LastCheckAt       *RFC3339DateTime `mailjet:"read_only"`
-	OwnerShipToken    string           `mailjet:"read_only"`
-	SPFRecordValue    string           `mailjet:"read_only"`
-	SPFStatus         string           `mailjet:"read_only"`
+	DKIMRecordName           string           `mailjet:"read_only"`
+	DKIMRecordValue          string           `mailjet:"read_only"`
+	DKIMStatus               string           `mailjet:"read_only"`
+	Domain                   string           `mailjet:"read_only"`
+	ID                       int64            `mailjet:"read_only"`
+	IsCheckInProgress        bool             `mailjet:"read_only"`
+	LastCheckAt              *RFC3339DateTime `mailjet:"read_only"`
+	OwnerShipToken           string           `mailjet:"read_only"`
+	OwnerShipTokenRecordName string           `mailjet:"read_only"`
+	SPFRecordValue           string           `mailjet:"read_only"`
+	SPFStatus                string           `mailjet:"read_only"`
 }
 
 type DnsCheck struct {


### PR DESCRIPTION
According to http://dev.mailjet.com/email-api/v3/dns/ (and experimentation through CURL) there is a "OwnerShipTokenRecordName". It would be nice if the Go API could support this as it saves me from having to do a manual HTTP call.