### PR TITLE
Add SenderValidate resource

### DIFF
--- a/resources/resources.go
+++ b/resources/resources.go
@@ -961,6 +961,13 @@ type Senderstatistics struct {
 	UnsubscribedCount  int64            `mailjet:"read_only"`
 }
 
+// SenderValidate: validation result for a sender or domain
+type SenderValidate struct {
+       Errors           map[string]string `mailjet:"read_only"`
+       ValidationMethod string            `mailjet:"read_only"`
+       GlobalError      string            `mailjet:"read_only"`
+}
+
 // Template: template description
 type Template struct {
 	Author      string   `json:",omitempty"`


### PR DESCRIPTION
This is based on the result described in
http://dev.mailjet.com/email-api/v3/sender-validate/ and
http://dev.mailjet.com/guides/#validate-sender-and-domain

While the resulting struct I've seen so far always contains only two specific keys for "Errors", namely "DNSValidationError" and "FileValidationError" there is no guarantee in the guide or in the API docs that these are the only allowed values and the API docs only say Errors is of type JSONObject. So I went for a relatively conservative approach: map[string]string. If this is not desirable please let me know and I'll change it to a proper struct.