### PR TITLE
InfoSendMail.{To,Cc,Bcc} should be simple strings

### DIFF
--- a/mailjet_resources.go
+++ b/mailjet_resources.go
@@ -74,9 +74,9 @@ type InfoSendMail struct {
 	FromName                 string
 	Sender                   string      `json:",omitempty"`
 	Recipients               []Recipient `json:",omitempty"`
-	To                       []string    `json:",omitempty"`
-	Cc                       []string    `json:",omitempty"`
-	Bcc                      []string    `json:",omitempty"`
+	To                       string      `json:",omitempty"`
+	Cc                       string      `json:",omitempty"`
+	Bcc                      string      `json:",omitempty"`
 	Subject                  string
 	TextPart                 string            `json:"Text-part,omitempty"`
 	HTMLPart                 string            `json:"Html-part,omitempty"`


### PR DESCRIPTION
This breaks API compatibility but if To is an array the mailjet
servers will not accept the request (400 Missing "To" or "Recipients"
property).

Per http://dev.mailjet.com/guides/?shell#sending-a-basic-email
multiple email addresses should be passed as a comma separated string.