### PR TITLE
add optionnal base API url configuration for mailjet.Client

### DIFF
--- a/core.go
+++ b/core.go
@@ -152,8 +152,8 @@ func userAgent(req *http.Request) {
 	req.Header.Add("User-Agent", ua)
 }
 
-func buildURL(info *Request) string {
-	tokens := []string{apiBase, apiPath, info.Resource}
+func buildURL(baseURL string, info *Request) string {
+	tokens := []string{baseURL, apiPath, info.Resource}
 	if info.ID != 0 {
 		id := strconv.FormatInt(info.ID, 10)
 		tokens = append(tokens, id)
@@ -170,8 +170,8 @@ func buildURL(info *Request) string {
 	return strings.Join(tokens, "/")
 }
 
-func buildDataURL(info *DataRequest) string {
-	tokens := []string{apiBase, dataPath, info.SourceType}
+func buildDataURL(baseURL string, info *DataRequest) string {
+	tokens := []string{baseURL, dataPath, info.SourceType}
 	if info.SourceTypeID != 0 {
 		id := strconv.FormatInt(info.SourceTypeID, 10)
 		tokens = append(tokens, id)

--- a/core_test.go
+++ b/core_test.go
@@ -76,7 +76,7 @@ func TestBuildUrl(t *testing.T) {
 		ActionID: 5,
 	}
 	expected := "https://api.mailjet.com/v3/REST/contactslist/1/managemanycontacts/5"
-	res := buildURL(info)
+	res := buildURL(apiBase, info)
 	if res != expected {
 		t.Fatal("Fail to build URL:", res)
 	}

--- a/data_api.go
+++ b/data_api.go
@@ -11,7 +11,7 @@ import (
 // and stores the result in the value pointed to by res.
 // Filters can be add via functional options.
 func (mj *Client) ListData(resource string, res interface{}, options ...RequestOptions) (count, total int, err error) {
-	url := buildDataURL(&DataRequest{SourceType: resource})
+	url := buildDataURL(mj.apiBase, &DataRequest{SourceType: resource})
 	req, err := createRequest("GET", url, nil, nil, options...)
 	if err != nil {
 		return count, total, err
@@ -32,7 +32,7 @@ func (mj *Client) ListData(resource string, res interface{}, options ...RequestO
 // Filters can be add via functional options.
 // Without an specified SourceTypeID in MailjetDataRequest, it is the same as ListData.
 func (mj *Client) GetData(mdr *DataRequest, res interface{}, options ...RequestOptions) (err error) {
-	url := buildDataURL(mdr)
+	url := buildDataURL(mj.apiBase, mdr)
 	req, err := createRequest("GET", url, nil, nil, options...)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func (mj *Client) GetData(mdr *DataRequest, res interface{}, options ...RequestO
 // and stores the result in the value pointed to by res.
 // Filters can be add via functional options.
 func (mj *Client) PostData(fmdr *FullDataRequest, res interface{}, options ...RequestOptions) (err error) {
-	url := buildDataURL(fmdr.Info)
+	url := buildDataURL(mj.apiBase, fmdr.Info)
 	req, err := createRequest("POST", url, fmdr.Payload, nil, options...)
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func (mj *Client) PostData(fmdr *FullDataRequest, res interface{}, options ...Re
 // If onlyFields is nil, all fields except these with the tag read_only, are updated.
 // Filters can be add via functional options.
 func (mj *Client) PutData(fmr *FullDataRequest, onlyFields []string, options ...RequestOptions) (err error) {
-	url := buildDataURL(fmr.Info)
+	url := buildDataURL(mj.apiBase, fmr.Info)
 	req, err := createRequest("PUT", url, fmr.Payload, onlyFields, options...)
 	if err != nil {
 		return err
@@ -103,7 +103,7 @@ func (mj *Client) PutData(fmr *FullDataRequest, onlyFields []string, options ...
 
 // DeleteData is used to delete a data resource.
 func (mj *Client) DeleteData(mdr *DataRequest) (err error) {
-	url := buildDataURL(mdr)
+	url := buildDataURL(mj.apiBase, mdr)
 	r, err := createRequest("DELETE", url, nil, nil)
 	if err != nil {
 		return err

--- a/mailjet_client_test.go
+++ b/mailjet_client_test.go
@@ -2,12 +2,13 @@ package mailjet
 
 import (
 	"fmt"
-	"github.com/mailjet/mailjet-apiv3-go/resources"
 	"math/rand"
 	"net/http"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/mailjet/mailjet-apiv3-go/resources"
 )
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/mailjet_resources.go
+++ b/mailjet_resources.go
@@ -13,6 +13,7 @@ import (
 type Client struct {
 	apiKeyPublic  string
 	apiKeyPrivate string
+	apiBase       string
 	client        *http.Client
 }
 


### PR DESCRIPTION
Hello,

I made some modification to add the support of the base api url configuration to mailjet.Client object.
The configuration is optional, so it does not change the regular way of using the wrapper.