### PR TITLE
Fix check on content_type header

### DIFF
--- a/core.go
+++ b/core.go
@@ -27,7 +27,7 @@ const (
 // User-Agent is formated as "UserAgentBase/UserAgentVersion;runtime.Version()".
 const (
 	UserAgentBase    = "mailjet-api-v3-go"
-	UserAgentVersion = "2.4.4"
+	UserAgentVersion = "2.4.5"
 )
 
 const (

--- a/core.go
+++ b/core.go
@@ -27,7 +27,7 @@ const (
 // User-Agent is formated as "UserAgentBase/UserAgentVersion;runtime.Version()".
 const (
 	UserAgentBase    = "mailjet-api-v3-go"
-	UserAgentVersion = "2.4.3"
+	UserAgentVersion = "2.4.4"
 )
 
 const (

--- a/http_client.go
+++ b/http_client.go
@@ -85,9 +85,9 @@ func (c *HTTPClient) Call() (count, total int, err error) {
 	if c.response != nil {
 		if resp.Header["Content-Type"] != nil {
 			contentType := resp.Header["Content-Type"][0]
-			if strings.EqualFold(contentType, "application/json") {
+			if strings.Contains(contentType, "application/json") {
 				return readJSONResult(resp.Body, c.response)
-			} else if strings.EqualFold(contentType, "text/csv") {
+			} else if strings.Contains(contentType, "text/csv") {
 				c.response, err = csv.NewReader(resp.Body).ReadAll()
 			}
 		}

--- a/http_client.go
+++ b/http_client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // HTTPClient is a wrapper arround http.Client
@@ -84,9 +85,9 @@ func (c *HTTPClient) Call() (count, total int, err error) {
 	if c.response != nil {
 		if resp.Header["Content-Type"] != nil {
 			contentType := resp.Header["Content-Type"][0]
-			if contentType == "application/json" {
+			if strings.EqualFold(contentType, "application/json") {
 				return readJSONResult(resp.Body, c.response)
-			} else if contentType == "text/csv" {
+			} else if strings.EqualFold(contentType, "text/csv") {
 				c.response, err = csv.NewReader(resp.Body).ReadAll()
 			}
 		}

--- a/http_client.go
+++ b/http_client.go
@@ -90,7 +90,7 @@ func (c *HTTPClient) Call() (count, total int, err error) {
 
 	if c.response != nil {
 		if resp.Header["Content-Type"] != nil {
-			contentType := resp.Header["Content-Type"][0]
+			contentType := strings.ToLower(resp.Header["Content-Type"][0])
 			if strings.Contains(contentType, "application/json") {
 				return readJSONResult(resp.Body, c.response)
 			} else if strings.Contains(contentType, "text/csv") {


### PR DESCRIPTION
The check of the content type header in http_client.go was comparing strings strictly with lowercase
Now the check has been made case insensitive