### PR TITLE
Update mailjet_resources.go TemplateID type

### DIFF
--- a/mailjet_resources.go
+++ b/mailjet_resources.go
@@ -176,7 +176,7 @@ type InfoMessagesV31 struct {
 	CustomID                 string                 `json:",omitempty"`
 	Variables                map[string]interface{} `json:",omitempty"`
 	EventPayload             string                 `json:",omitempty"`
-	TemplateID               interface{}            `json:",omitempty"`
+	TemplateID               int                    `json:",omitempty"`
 	TemplateLanguage         bool                   `json:",omitempty"`
 	TemplateErrorReporting   *RecipientV31          `json:",omitempty"`
 	TemplateErrorDeliver     bool                   `json:",omitempty"`


### PR DESCRIPTION
Change InfoMessagesV31 struct TemplateID from interface{} to int. 
`{"Messages":[{"Errors":[{"ErrorClass":"","ErrorMessage":"Type mismatch. Expected type \"integer\".","ErrorRelatedTo":["TemplateID"],"StatusCode":400}]}]}
`