### PR TITLE
added object structure for MJML Content

### DIFF
--- a/resources/resources.go
+++ b/resources/resources.go
@@ -992,8 +992,15 @@ type Template struct {
 type TemplateDetailcontent struct {
 	TextPart    string      `json:"Text-part,omitempty"`
 	HtmlPart    string      `json:"Html-part,omitempty"`
-	MJMLContent string      `json:",omitempty"`
+	MJMLContent MJMLContent `json:",omitempty"`
 	Headers     interface{} `json:",omitempty"`
+}
+
+// MJMLContent: Structure of Passport template.
+type MJMLContent struct {
+	tagName    string
+	attributes map[string]interface{}
+	id         string
 }
 
 // Toplinkclicked: Top links clicked historgram.


### PR DESCRIPTION
added object structure for MJML Content to ensure api library works with `template/:id/detailcontent`