### PR TITLE
Implement optional MessageUUID to SAPI 3.0 response

### DIFF
--- a/mailjet_resources.go
+++ b/mailjet_resources.go
@@ -126,8 +126,9 @@ type Attachment struct {
 // SentResult is the JSON result sent by the Send API.
 type SentResult struct {
 	Sent []struct {
-		Email     string
-		MessageID int64
+		Email       string `json:"Email"`
+		MessageID   int64  `json:"MessageID"`
+		MessageUUID string `json:"MessageUUID,omitempty"`
 	}
 }
 


### PR DESCRIPTION
This PR is relative to the change to come in june.
SAPI 3.0 will have a new field MessageUUID.

```
{
    "Sent": [
        {
            "Email": "passenger@mailjet.com",
            "MessageID": 111111111111111,
            "MessageUUID": "97b82931-b9f0-4690-aaab-347e66e17e9c"
        }
    ]
}
```