### PR TITLE
Add DNSID field to Sender res

### DIFF
--- a/core.go
+++ b/core.go
@@ -27,7 +27,7 @@ const (
 // User-Agent is formated as "UserAgentBase/UserAgentVersion;runtime.Version()".
 const (
 	UserAgentBase    = "mailjet-api-v3-go"
-	UserAgentVersion = "2.4.5"
+	UserAgentVersion = "2.5.0"
 )
 
 const (

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -938,7 +938,8 @@ type Preset struct {
 // In order to manage a sender available across multiple API keys, see the related MetaSender resource.
 type Sender struct {
 	CreatedAt       *RFC3339DateTime `mailjet:"read_only"`
-	DNS             string           `mailjet:"read_only"`
+	DNS             string           `mailjet:"read_only"` // deprecated
+	DNSID           int64            `mailjet:"read_only"`
 	Email           string
 	EmailType       string `json:",omitempty"`
 	Filename        string `mailjet:"read_only"`


### PR DESCRIPTION
The root cause is the mismatching JSON's `DNSID` field type (number) and `DNS` file type (string) in the `Sender` struct. 

Add `DNSID int64` field to `Sender`. The existing `DNS string` field left for backward compatibility.