### PR TITLE
Remove read_only attribute for listrecipient resource

### DIFF
--- a/mailjet_client_test.go
+++ b/mailjet_client_test.go
@@ -80,24 +80,45 @@ func TestCreateListrecipient(t *testing.T) {
 		}
 	})
 
-	req := &mailjet.Request{
-		Resource: "listrecipient",
-	}
-	fullRequest := &mailjet.FullRequest{
-		Info: req,
-		Payload: resources.Listrecipient{
-			IsUnsubscribed: true,
-			ContactID:      124409882,
-			ContactALT:     "joe.doe@mailjet.com",
-			ListID:         32964,
-		},
-	}
+	t.Run("successfully create list", func(t *testing.T) {
+		req := &mailjet.Request{
+			Resource: "listrecipient",
+		}
+		fullRequest := &mailjet.FullRequest{
+			Info: req,
+			Payload: resources.Listrecipient{
+				IsUnsubscribed: true,
+				ContactID:      124409882,
+				ContactALT:     "joe.doe@mailjet.com",
+				ListID:         32964,
+			},
+		}
 
-	var resp []resources.Listrecipient
-	err := client.Post(fullRequest, &resp)
-	if err != nil {
-		t.Fatal(err)
-	}
+		var resp []resources.Listrecipient
+		err := client.Post(fullRequest, &resp)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("failure when required parameters missing", func(t *testing.T) {
+		req := &mailjet.Request{
+			Resource: "listrecipient",
+		}
+		fullRequest := &mailjet.FullRequest{
+			Info: req,
+			Payload: resources.Listrecipient{
+				IsUnsubscribed: true,
+				ListID:         32964,
+			},
+		}
+
+		var resp []resources.Listrecipient
+		err := client.Post(fullRequest, &resp)
+		if err == nil {
+			t.Fatal("Expected error")
+		}
+	})
 }
 
 func TestUnitList(t *testing.T) {

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -551,8 +551,8 @@ type Graphstatistics struct {
 
 // Listrecipient: Manage the relationship between a contact and a contactslists.
 type Listrecipient struct {
-	ContactID      int64            `mailjet:"read_only"`
-	ContactALT     string           `mailjet:"read_only"`
+	ContactID      int64            `json:",omitempty"`
+	ContactALT     string           `json:",omitempty"`
 	ID             int64            `mailjet:"read_only"`
 	IsActive       bool             `json:",omitempty"`
 	IsUnsubscribed bool             `json:",omitempty"`


### PR DESCRIPTION
Remove `read_only` attribute for `ContactID` and `ContactALT` fields in `Listrecipient` resource.
Add test.