### PR TITLE
Update SpamAssassinRules's field type in Message and Messageinformation resources

### DIFF
--- a/mailjet_client_test.go
+++ b/mailjet_client_test.go
@@ -135,35 +135,35 @@ func TestMessage(t *testing.T) {
 
 	handle("/v3/REST/message", `
 	{
-	  "Count": 1,
-	  "Data": [
-	    {
-	      "ArrivedAt": "2020-10-08T06:36:35Z",
-	      "AttachmentCount": 0,
-	      "AttemptCount": 0,
-	      "CampaignID": 426400,
-	      "ContactAlt": "",
-	      "ContactID": 124409882,
-	      "Delay": 0,
-	      "DestinationID": 124879,
-	      "FilterTime": 0,
-	      "ID": 94294117474376580,
-	      "IsClickTracked": false,
-	      "IsHTMLPartIncluded": false,
-	      "IsOpenTracked": true,
-	      "IsTextPartIncluded": false,
-	      "IsUnsubTracked": false,
-	      "MessageSize": 810,
-	      "SenderID": 52387,
-	      "SpamassassinScore": 0,
-	      "SpamassRules": "",
-	      "StatePermanent": false,
-	      "Status": "sent",
-	      "Subject": "",
-	      "UUID": "6f66806a-c4d6-4a33-99dc-bedbc7c4217f"
-	    }
-	  ],
-	  "Total": 1
+		"Count": 1,
+		"Data": [
+			{
+				"ArrivedAt": "2020-10-08T06:36:35Z",
+				"AttachmentCount": 0,
+				"AttemptCount": 0,
+				"CampaignID": 426400,
+				"ContactAlt": "",
+				"ContactID": 124409882,
+				"Delay": 0,
+				"DestinationID": 124879,
+				"FilterTime": 0,
+				"ID": 94294117474376580,
+				"IsClickTracked": false,
+				"IsHTMLPartIncluded": false,
+				"IsOpenTracked": true,
+				"IsTextPartIncluded": false,
+				"IsUnsubTracked": false,
+				"MessageSize": 810,
+				"SenderID": 52387,
+				"SpamassassinScore": 0,
+				"SpamassRules": "",
+				"StatePermanent": false,
+				"Status": "sent",
+				"Subject": "",
+				"UUID": "6f66806a-c4d6-4a33-99dc-bedbc7c4217f"
+			}
+		],
+		"Total": 1
 	}
    `)
 

--- a/mailjet_client_test.go
+++ b/mailjet_client_test.go
@@ -33,6 +33,14 @@ func fakeServer() func() {
 	}
 }
 
+func handle(path, response string) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, response)
+	})
+}
+
 func randSeq(n int) string {
 	rand.Seed(time.Now().UnixNano())
 	b := make([]rune, n)
@@ -119,6 +127,56 @@ func TestCreateListrecipient(t *testing.T) {
 			t.Fatal("Expected error")
 		}
 	})
+}
+
+func TestMessage(t *testing.T) {
+	teardown := fakeServer()
+	defer teardown()
+
+	handle("/v3/REST/message", `
+	{
+	  "Count": 1,
+	  "Data": [
+	    {
+	      "ArrivedAt": "2020-10-08T06:36:35Z",
+	      "AttachmentCount": 0,
+	      "AttemptCount": 0,
+	      "CampaignID": 426400,
+	      "ContactAlt": "",
+	      "ContactID": 124409882,
+	      "Delay": 0,
+	      "DestinationID": 124879,
+	      "FilterTime": 0,
+	      "ID": 94294117474376580,
+	      "IsClickTracked": false,
+	      "IsHTMLPartIncluded": false,
+	      "IsOpenTracked": true,
+	      "IsTextPartIncluded": false,
+	      "IsUnsubTracked": false,
+	      "MessageSize": 810,
+	      "SenderID": 52387,
+	      "SpamassassinScore": 0,
+	      "SpamassRules": "",
+	      "StatePermanent": false,
+	      "Status": "sent",
+	      "Subject": "",
+	      "UUID": "6f66806a-c4d6-4a33-99dc-bedbc7c4217f"
+	    }
+	  ],
+	  "Total": 1
+	}
+   `)
+
+	request := &mailjet.Request{
+		Resource: "message",
+	}
+
+	var data []resources.Message
+
+	err := client.Get(request, &data)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestUnitList(t *testing.T) {

--- a/mailjet_client_test.go
+++ b/mailjet_client_test.go
@@ -179,6 +179,108 @@ func TestMessage(t *testing.T) {
 	}
 }
 
+func TestMessageinformation(t *testing.T) {
+	t.Run("empty SpamAssassinRules", func(t *testing.T) {
+		teardown := fakeServer()
+		defer teardown()
+
+		handle("/v3/REST/messageinformation", `
+		{
+			"Count": 1,
+			"Data": [
+				{
+					"CampaignID": 0,
+					"ClickTrackedCount": 0,
+					"ContactID": 124409882,
+					"CreatedAt": "2020-10-09T06:07:56Z",
+					"ID": 288230380871887400,
+					"MessageSize": 434,
+					"OpenTrackedCount": 0,
+					"QueuedCount": 0,
+					"SendEndAt": "2020-10-09T06:07:56Z",
+					"SentCount": 1602223677,
+					"SpamAssassinRules": {
+						"ALT": "",
+						"ID": -1
+					},
+					"SpamAssassinScore": 0
+				}
+			],
+			"Total": 1
+		}
+		`)
+
+		request := &mailjet.Request{
+			Resource: "messageinformation",
+		}
+
+		var data []resources.Messageinformation
+
+		err := client.Get(request, &data)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("not empty SpamAssassinRules", func(t *testing.T) {
+		teardown := fakeServer()
+		defer teardown()
+
+		handle("/v3/REST/messageinformation", `
+		{
+			"Count": 1,
+			"Data": [
+				{
+					"CampaignID": 0,
+					"ClickTrackedCount": 0,
+					"ContactID": 124409882,
+					"CreatedAt": "2020-10-09T06:07:56Z",
+					"ID": 288230380871887400,
+					"MessageSize": 434,
+					"OpenTrackedCount": 0,
+					"QueuedCount": 0,
+					"SendEndAt": "2020-10-09T06:07:56Z",
+					"SentCount": 1602223677,
+					"SpamAssassinRules": {
+						"ALT": "",
+						"ID": -1,
+						"Items": [
+							{
+								"ALT": "MISSING_DATE",
+								"HitCount": 81115,
+								"ID": 1,
+								"Name": "MISSING_DATE",
+								"Score": 2.739
+							},
+							{
+								"ALT": "MISSING_HEADERS",
+								"HitCount": 48433743,
+								"ID": 2,
+								"Name": "MISSING_HEADERS",
+								"Score": 0.915
+							}
+						]
+					},
+					"SpamAssassinScore": 0
+				}
+			],
+			"Total": 1
+		}
+		`)
+
+		request := &mailjet.Request{
+			Resource: "messageinformation",
+		}
+
+		var data []resources.Messageinformation
+
+		err := client.Get(request, &data)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestUnitList(t *testing.T) {
 	m := newMockedMailjetClient()
 

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -636,20 +636,22 @@ type Messagehistory struct {
 
 // Messageinformation: API Key campaign/message information.
 type Messageinformation struct {
-	CampaignID        int64              `mailjet:"read_only"`
-	CampaignALT       string             `mailjet:"read_only"`
-	ClickTrackedCount int64              `mailjet:"read_only"`
-	ContactID         int64              `mailjet:"read_only"`
-	ContactALT        string             `mailjet:"read_only"`
-	CreatedAt         *RFC3339DateTime   `mailjet:"read_only"`
-	ID                int64              `mailjet:"read_only"`
-	MessageSize       int64              `mailjet:"read_only"`
-	OpenTrackedCount  int64              `mailjet:"read_only"`
-	QueuedCount       int64              `mailjet:"read_only"`
-	SendEndAt         *RFC3339DateTime   `mailjet:"read_only"`
-	SentCount         int64              `mailjet:"read_only"`
-	SpamAssassinRules []SpamAssassinRule `mailjet:"read_only"`
-	SpamAssassinScore float64            `mailjet:"read_only"`
+	CampaignID        int64            `mailjet:"read_only"`
+	CampaignALT       string           `mailjet:"read_only"`
+	ClickTrackedCount int64            `mailjet:"read_only"`
+	ContactID         int64            `mailjet:"read_only"`
+	ContactALT        string           `mailjet:"read_only"`
+	CreatedAt         *RFC3339DateTime `mailjet:"read_only"`
+	ID                int64            `mailjet:"read_only"`
+	MessageSize       int64            `mailjet:"read_only"`
+	OpenTrackedCount  int64            `mailjet:"read_only"`
+	QueuedCount       int64            `mailjet:"read_only"`
+	SendEndAt         *RFC3339DateTime `mailjet:"read_only"`
+	SentCount         int64            `mailjet:"read_only"`
+	SpamAssassinRules struct {
+		Items []SpamAssassinRule
+	} `mailjet:"read_only"`
+	SpamAssassinScore float64 `mailjet:"read_only"`
 }
 
 // Messagesentstatistics: API Key Statistical campaign/message data.

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -608,21 +608,21 @@ type Message struct {
 	ContactALT         string           `json:",omitempty"`
 	Delay              float64          `json:",omitempty"`
 	Destination        Destination
-	FilterTime         int                `json:",omitempty"`
-	FromID             int64              `json:",omitempty"`
-	FromALT            string             `json:",omitempty"`
-	ID                 int64              `mailjet:"read_only"`
-	IsClickTracked     bool               `json:",omitempty"`
-	IsHTMLPartIncluded bool               `json:",omitempty"`
-	IsOpenTracked      bool               `json:",omitempty"`
-	IsTextPartIncluded bool               `json:",omitempty"`
-	IsUnsubTracked     bool               `json:",omitempty"`
-	MessageSize        int64              `json:",omitempty"`
-	SpamassassinScore  float64            `json:",omitempty"`
-	SpamassRules       []SpamAssassinRule `json:",omitempty"`
-	StateID            int64              `json:",omitempty"`
-	StatePermanent     bool               `json:",omitempty"`
-	Status             string             `json:",omitempty"`
+	FilterTime         int     `json:",omitempty"`
+	FromID             int64   `json:",omitempty"`
+	FromALT            string  `json:",omitempty"`
+	ID                 int64   `mailjet:"read_only"`
+	IsClickTracked     bool    `json:",omitempty"`
+	IsHTMLPartIncluded bool    `json:",omitempty"`
+	IsOpenTracked      bool    `json:",omitempty"`
+	IsTextPartIncluded bool    `json:",omitempty"`
+	IsUnsubTracked     bool    `json:",omitempty"`
+	MessageSize        int64   `json:",omitempty"`
+	SpamassassinScore  float64 `json:",omitempty"`
+	SpamassRules       string  `json:",omitempty"`
+	StateID            int64   `json:",omitempty"`
+	StatePermanent     bool    `json:",omitempty"`
+	Status             string  `json:",omitempty"`
 }
 
 // Messagehistory: Event history of a message.


### PR DESCRIPTION
`Message` resource - change `SpamassRules` field type `[]SpamAssassinRule` -> `string`
`Messageinformation` resource - change `SpamAssassinRules` type `[]SpamAssassinRule` -> `struct { Items []SpamAssassinRule }`
Add tests for `/message` and `/messageinformation` endpoints.
