### PR TITLE
Return an error for mock `SendMailV31Func` function instead of nil

### DIFF
--- a/http_client_mock.go
+++ b/http_client_mock.go
@@ -36,7 +36,7 @@ func NewhttpClientMock(valid bool) *HTTPClientMock {
 			return 0, 0, errors.New("Unexpected error: Unexpected server response code: 401: EOF")
 		},
 		SendMailV31Func: func(req *http.Request) (*http.Response, error) {
-			return nil, nil
+			return nil, errors.New("mock send mail function not implemented yet")
 		},
 	}
 }


### PR DESCRIPTION
To avoid users getting panics.
resolves #55 