### PR TITLE
Add contextful Client methods

### DIFF
--- a/core.go
+++ b/core.go
@@ -2,6 +2,7 @@ package mailjet
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,7 +38,7 @@ const (
 )
 
 // createRequest is the main core function.
-func createRequest(method string, url string,
+func createRequest(ctx context.Context, method string, url string,
 	payload interface{}, onlyFields []string,
 	options ...RequestOptions) (req *http.Request, err error) {
 
@@ -45,7 +46,7 @@ func createRequest(method string, url string,
 	if err != nil {
 		return req, fmt.Errorf("creating request: %s\n", err)
 	}
-	req, err = http.NewRequest(method, url, bytes.NewBuffer(body))
+	req, err = http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(body))
 	if err != nil {
 		return req, fmt.Errorf("creating request: %s\n", err)
 	}

--- a/core_test.go
+++ b/core_test.go
@@ -2,6 +2,7 @@ package mailjet
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"runtime"
@@ -10,7 +11,7 @@ import (
 )
 
 func TestCreateRequest(t *testing.T) {
-	req, err := createRequest("GET", apiBase, nil, nil)
+	req, err := createRequest(context.Background(), "GET", apiBase, nil, nil)
 	if err != nil {
 		t.Fatal("Unexpected error:", err)
 	}

--- a/data_api.go
+++ b/data_api.go
@@ -1,13 +1,16 @@
 package mailjet
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
 // ListData issues a GET to list the specified data resource
 // and stores the result in the value pointed to by res.
 // Filters can be add via functional options.
 func (mj *Client) ListData(resource string, resp interface{}, options ...RequestOptions) (count, total int, err error) {
 	url := buildDataURL(mj.apiBase, &DataRequest{SourceType: resource})
-	req, err := createRequest("GET", url, nil, nil, options...)
+	req, err := createRequest(context.Background(), "GET", url, nil, nil, options...)
 	if err != nil {
 		return count, total, err
 	}
@@ -21,7 +24,7 @@ func (mj *Client) ListData(resource string, resp interface{}, options ...Request
 // Without an specified SourceTypeID in MailjetDataRequest, it is the same as ListData.
 func (mj *Client) GetData(mdr *DataRequest, res interface{}, options ...RequestOptions) (err error) {
 	url := buildDataURL(mj.apiBase, mdr)
-	req, err := createRequest("GET", url, nil, nil, options...)
+	req, err := createRequest(context.Background(), "GET", url, nil, nil, options...)
 	if err != nil {
 		return err
 	}
@@ -35,7 +38,7 @@ func (mj *Client) GetData(mdr *DataRequest, res interface{}, options ...RequestO
 // Filters can be add via functional options.
 func (mj *Client) PostData(fmdr *FullDataRequest, res interface{}, options ...RequestOptions) (err error) {
 	url := buildDataURL(mj.apiBase, fmdr.Info)
-	req, err := createRequest("POST", url, fmdr.Payload, nil, options...)
+	req, err := createRequest(context.Background(), "POST", url, fmdr.Payload, nil, options...)
 	if err != nil {
 		return err
 	}
@@ -56,7 +59,7 @@ func (mj *Client) PostData(fmdr *FullDataRequest, res interface{}, options ...Re
 // Filters can be add via functional options.
 func (mj *Client) PutData(fmr *FullDataRequest, onlyFields []string, options ...RequestOptions) (err error) {
 	url := buildDataURL(mj.apiBase, fmr.Info)
-	req, err := createRequest("PUT", url, fmr.Payload, onlyFields, options...)
+	req, err := createRequest(context.Background(), "PUT", url, fmr.Payload, onlyFields, options...)
 	if err != nil {
 		return err
 	}
@@ -70,7 +73,7 @@ func (mj *Client) PutData(fmr *FullDataRequest, onlyFields []string, options ...
 // DeleteData is used to delete a data resource.
 func (mj *Client) DeleteData(mdr *DataRequest) (err error) {
 	url := buildDataURL(mj.apiBase, mdr)
-	req, err := createRequest("DELETE", url, nil, nil)
+	req, err := createRequest(context.Background(), "DELETE", url, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/mailjet_client.go
+++ b/mailjet_client.go
@@ -6,6 +6,7 @@ package mailjet
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"encoding/json"
@@ -124,8 +125,17 @@ func Sort(value string, order SortOrder) RequestOptions {
 // and stores the result in the value pointed to by res.
 // Filters can be add via functional options.
 func (c *Client) List(resource string, resp interface{}, options ...RequestOptions) (count, total int, err error) {
+	return c.ListWithContext(context.Background(), resource, resp, options...)
+}
+
+// ListWithContext behaves like List, but allows the caller to supply a context.Context
+// for cancellation and deadlines.
+func (c *Client) ListWithContext(ctx context.Context, resource string, resp interface{}, options ...RequestOptions) (count, total int, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	url := buildURL(c.apiBase, &Request{Resource: resource})
-	req, err := createRequest("GET", url, nil, nil, options...)
+	req, err := createRequest(ctx, "GET", url, nil, nil, options...)
 	if err != nil {
 		return count, total, err
 	}
@@ -140,8 +150,17 @@ func (c *Client) List(resource string, resp interface{}, options ...RequestOptio
 // Filters can be add via functional options.
 // Without an specified ID in MailjetRequest, it is the same as List.
 func (c *Client) Get(mr *Request, resp interface{}, options ...RequestOptions) (err error) {
+	return c.GetWithContext(context.Background(), mr, resp, options...)
+}
+
+// GetWithContext behaves like Get, but allows the caller to supply a context.Context
+// for cancellation and deadlines.
+func (c *Client) GetWithContext(ctx context.Context, mr *Request, resp interface{}, options ...RequestOptions) (err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	url := buildURL(c.apiBase, mr)
-	req, err := createRequest("GET", url, nil, nil, options...)
+	req, err := createRequest(ctx, "GET", url, nil, nil, options...)
 	if err != nil {
 		return err
 	}
@@ -156,8 +175,17 @@ func (c *Client) Get(mr *Request, resp interface{}, options ...RequestOptions) (
 // and stores the result in the value pointed to by res.
 // Filters can be add via functional options.
 func (c *Client) Post(fmr *FullRequest, resp interface{}, options ...RequestOptions) (err error) {
+	return c.PostWithContext(context.Background(), fmr, resp, options...)
+}
+
+// PostWithContext behaves like Post, but allows the caller to supply a context.Context
+// for cancellation and deadlines.
+func (c *Client) PostWithContext(ctx context.Context, fmr *FullRequest, resp interface{}, options ...RequestOptions) (err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	url := buildURL(c.apiBase, fmr.Info)
-	req, err := createRequest("POST", url, fmr.Payload, nil, options...)
+	req, err := createRequest(ctx, "POST", url, fmr.Payload, nil, options...)
 	if err != nil {
 		return err
 	}
@@ -174,8 +202,17 @@ func (c *Client) Post(fmr *FullRequest, resp interface{}, options ...RequestOpti
 // If onlyFields is nil, all fields except these with the tag read_only, are updated.
 // Filters can be add via functional options.
 func (c *Client) Put(fmr *FullRequest, onlyFields []string, options ...RequestOptions) (err error) {
+	return c.PutWithContext(context.Background(), fmr, onlyFields, options...)
+}
+
+// PutWithContext behaves like Put, but allows the caller to supply a context.Context
+// for cancellation and deadlines.
+func (c *Client) PutWithContext(ctx context.Context, fmr *FullRequest, onlyFields []string, options ...RequestOptions) (err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	url := buildURL(c.apiBase, fmr.Info)
-	req, err := createRequest("PUT", url, fmr.Payload, onlyFields, options...)
+	req, err := createRequest(ctx, "PUT", url, fmr.Payload, onlyFields, options...)
 	if err != nil {
 		return err
 	}
@@ -189,8 +226,17 @@ func (c *Client) Put(fmr *FullRequest, onlyFields []string, options ...RequestOp
 
 // Delete is used to delete a resource.
 func (c *Client) Delete(mr *Request) (err error) {
+	return c.DeleteWithContext(context.Background(), mr)
+}
+
+// DeleteWithContext behaves like Delete, but allows the caller to supply a context.Context
+// for cancellation and deadlines.
+func (c *Client) DeleteWithContext(ctx context.Context, mr *Request) (err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	url := buildURL(c.apiBase, mr)
-	req, err := createRequest("DELETE", url, nil, nil)
+	req, err := createRequest(ctx, "DELETE", url, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -203,8 +249,17 @@ func (c *Client) Delete(mr *Request) (err error) {
 
 // SendMail send mail via API.
 func (c *Client) SendMail(data *InfoSendMail) (res *SentResult, err error) {
+	return c.SendMailWithContext(context.Background(), data)
+}
+
+// SendMailWithContext behaves like SendMail, but allows the caller to supply a context.Context
+// for cancellation and deadlines.
+func (c *Client) SendMailWithContext(ctx context.Context, data *InfoSendMail) (res *SentResult, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	url := c.apiBase + "/send/message"
-	req, err := createRequest("POST", url, data, nil)
+	req, err := createRequest(ctx, "POST", url, data, nil)
 	if err != nil {
 		return res, err
 	}
@@ -238,8 +293,17 @@ func buildMessage(header textproto.MIMEHeader, content []byte) []byte {
 
 // SendMailV31 sends a mail to the send API v3.1
 func (c *Client) SendMailV31(data *MessagesV31) (*ResultsV31, error) {
+	return c.SendMailV31WithContext(context.Background(), data)
+}
+
+// SendMailV31WithContext behaves like SendMailV31, but allows the caller
+// to supply a context.Context for cancellation and deadlines.
+func (c *Client) SendMailV31WithContext(ctx context.Context, data *MessagesV31) (*ResultsV31, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	url := c.apiBase + ".1/send"
-	req, err := createRequest("POST", url, data, nil)
+	req, err := createRequest(ctx, "POST", url, data, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/mailjet_client_decl.go
+++ b/mailjet_client_decl.go
@@ -4,19 +4,28 @@
 // For more details, see the full API Documentation at http://dev.mailjet.com/
 package mailjet
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
-// ClientInterface defines all Clients fuctions.
+// ClientInterface defines all Clients functions.
 type ClientInterface interface {
 	APIKeyPublic() string
 	APIKeyPrivate() string
 	Client() *http.Client
 	SetClient(client *http.Client)
 	List(resource string, resp interface{}, options ...RequestOptions) (count, total int, err error)
+	ListWithContext(ctx context.Context, resource string, resp interface{}, options ...RequestOptions) (count, total int, err error)
 	Get(mr *Request, resp interface{}, options ...RequestOptions) error
+	GetWithContext(ctx context.Context, mr *Request, resp interface{}, options ...RequestOptions) error
 	Post(fmr *FullRequest, resp interface{}, options ...RequestOptions) error
+	PostWithContext(ctx context.Context, fmr *FullRequest, resp interface{}, options ...RequestOptions) error
 	Put(fmr *FullRequest, onlyFields []string, options ...RequestOptions) error
+	PutWithContext(ctx context.Context, fmr *FullRequest, onlyFields []string, options ...RequestOptions) error
 	Delete(mr *Request) error
+	DeleteWithContext(ctx context.Context, mr *Request) error
 	SendMail(data *InfoSendMail) (*SentResult, error)
+	SendMailWithContext(ctx context.Context, data *InfoSendMail) (*SentResult, error)
 	SendMailSMTP(info *InfoSMTP) (err error)
 }


### PR DESCRIPTION
The Mailjet Client has not had methods for passing through a context.Context, enabling the caller to cancel or set deadlines for the operations. 

This is a feature which is commonly found on similar libraries, and for which the net/http package provides built-in support by attaching the context to the http.Request. 

This branch adds Client methods which support context.Context in a way which is fully backwards compatible.