### PR TITLE
Fix overriding exclusion state

### DIFF
--- a/resources/resources.go
+++ b/resources/resources.go
@@ -1185,7 +1185,7 @@ type ContactsListAction struct {
 type AddContactAction struct {
 	Email                   string
 	Name                    string
-	IsExcludedFromCampaigns bool
+	IsExcludedFromCampaigns *bool `json:",omitempty"`
 	Properties              JSONObject
 }
 


### PR DESCRIPTION
resolves #90 

Make the `IsExcludedFromCampaigns` field in the `AddContactAction` type as a pointer with `omitempty` to not include that field if not set. Otherwise the update request with this field not set will override the previous state to false when it should preserve it.