### PR TITLE
Use separate http client instead of default one

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -22,7 +22,7 @@ func NewHTTPClient(apiKeyPublic, apiKeyPrivate string) *HTTPClient {
 	return &HTTPClient{
 		apiKeyPublic:  apiKeyPublic,
 		apiKeyPrivate: apiKeyPrivate,
-		client:        http.DefaultClient,
+		client:        &http.Client{},
 	}
 }
 


### PR DESCRIPTION
Since `http.DefaultClient` is not immutable and can be changed by others, it's better to use a separate HTTP client.