### PR TITLE
Close the response body in SendMailV31()

### DIFF
--- a/mailjet_client.go
+++ b/mailjet_client.go
@@ -259,6 +259,7 @@ func (c *Client) SendMailV31(data *MessagesV31, options ...RequestOptions) (*Res
 	if err != nil {
 		return nil, err
 	}
+	defer r.Body.Close()
 
 	decoder := json.NewDecoder(r.Body)
 


### PR DESCRIPTION
Hi,

This fixes a missing call to Body.Close() on the HTTP response in Client.SendMailV31()